### PR TITLE
Fix position for scrolled page

### DIFF
--- a/wow-alert.css
+++ b/wow-alert.css
@@ -18,7 +18,7 @@
     -webkit-border-radius:3px;
     border-radius:3px;
     -khtml-border-radius:3px;
-    position:absolute;
+    position:fixed;
     z-index:99999999;
     min-width:200px;
     min-height:50px;


### PR DESCRIPTION
When page is scrolled horisontally, alert does not appear on visible part of screen.
